### PR TITLE
Add a way to run the core tests with other plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ To test a specific plugin branch against a particular ManageIQ SHA
 TEST_REPO=manageiq-ui-classic@branch-name MANAGEIQ_CORE_REF=1234abcd bundle exec rake test:plugin
 ```
 
-To run the core tests with ManageIQ master using a specific plugin
+To run the core tests with ManageIQ master using a specific gem version
 
 ```ruby
-PLUGIN_REPOS=johndoe/manageiq-ui-classic@branch-name bundle exec rake test:core
+GEM_REPOS=johndoe/manageiq-ui-classic@branch-name bundle exec rake test:core
 ```
 
-To run the core tests for a branch and a set of plugins
+To run the core tests for a branch and a set of gems
 
 ```ruby
-CORE_REPO=johndoe/manageiq@feature PLUGIN_REPOS=johndoe/manageiq-ui-classic@feature,johndoe/manageiq-api@feature bundle exec rake test:core
+CORE_REPO=johndoe/manageiq@feature GEM_REPOS=johndoe/manageiq-ui-classic@feature,johndoe/manageiq-api@feature bundle exec rake test:core
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ To test a specific plugin branch against a particular ManageIQ SHA
 TEST_REPO=manageiq-ui-classic@branch-name MANAGEIQ_CORE_REF=1234abcd bundle exec rake test:plugin
 ```
 
+To run the core tests with ManageIQ master using a specific plugin
+
+```ruby
+PLUGIN_REPOS=johndoe/manageiq-ui-classic@branch-name bundle exec rake test:core
+```
+
+To run the core tests for a branch and a set of plugins
+
+```ruby
+CORE_REPO=johndoe/manageiq@feature PLUGIN_REPOS=johndoe/manageiq-ui-classic@feature,johndoe/manageiq-api@feature bundle exec rake test:core
+```
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/Rakefile
+++ b/Rakefile
@@ -7,19 +7,19 @@ namespace :test do
   desc "Run core tests"
   task :core do
     core_repo = ENV["CORE_REPO"]
-    plugin_repos = ENV["PLUGIN_REPOS"]&.split(",")
+    gem_repos = ENV["GEM_REPOS"]&.split(",")
 
     # It doesn't make sense to use this without passing anything, since that would
     # be equivalent to just running specs on master
-    if core_repo.blank? && plugin_repos.blank?
-      STDERR.puts "ERROR: must pass either a CORE_REPO or at least one PLUGIN_REPOS"
+    if core_repo.blank? && gem_repos.blank?
+      STDERR.puts "ERROR: must pass either a CORE_REPO or at least one GEM_REPOS"
       exit 1
     end
 
     # If no core repo was specified just use ManageIQ/manageiq@master
     core_repo ||= "ManageIQ/manageiq@master"
 
-    ManageIQ::CrossRepo::TestCore.new(core_repo, plugin_repos).run
+    ManageIQ::CrossRepo::TestCore.new(core_repo, gem_repos).run
   end
 
   desc "Run plugin tests"

--- a/lib/manageiq/cross_repo.rb
+++ b/lib/manageiq/cross_repo.rb
@@ -1,4 +1,6 @@
 require "manageiq/cross_repo/version"
+require "manageiq/cross_repo/test_base"
+require "manageiq/cross_repo/test_core"
 require "manageiq/cross_repo/test_plugin"
 
 require "pathname"

--- a/lib/manageiq/cross_repo/repository.rb
+++ b/lib/manageiq/cross_repo/repository.rb
@@ -11,15 +11,12 @@ module ManageIQ::CrossRepo
     def initialize(identifier, server: "https://github.com")
       name, ref = identifier.split("@")
       org, repo = name.split("/")
-      if repo.nil?
-        repo = org
-        org = "ManageIQ"
-      end
+      repo, org = org, "ManageIQ" if repo.nil?
 
       self.server = server
-      self.org = org
-      self.repo = repo
-      self.ref = ref || "master"
+      self.org    = org
+      self.repo   = repo
+      self.ref    = ref || "master"
     end
 
     def name

--- a/lib/manageiq/cross_repo/repository.rb
+++ b/lib/manageiq/cross_repo/repository.rb
@@ -29,7 +29,7 @@ module ManageIQ::CrossRepo
       File.join(server, org, repo, "tarball", ref)
     end
 
-    def dir
+    def path
       REPOS_DIR.join(name)
     end
   end

--- a/lib/manageiq/cross_repo/repository.rb
+++ b/lib/manageiq/cross_repo/repository.rb
@@ -4,9 +4,10 @@ module ManageIQ::CrossRepo
 
     # ManageIQ::CrossRepo::Repository
     #
-    # #initialize(identifier, server: "https://github.com")
-    #
-    # identifier can be [org/]repo[@ref]
+    # @param identifier [String] the short representation of a repository relative to a server, format [org/]repo[@ref]
+    # @param server [String] The git repo server hosting this repository, default: https://github.com
+    # @example
+    #   Repostory.new("ManageIQ/manageiq@master", server: "https://github.com")
     def initialize(identifier, server: "https://github.com")
       name, ref = identifier.split("@")
       org, repo = name.split("/")

--- a/lib/manageiq/cross_repo/repository.rb
+++ b/lib/manageiq/cross_repo/repository.rb
@@ -1,0 +1,36 @@
+module ManageIQ::CrossRepo
+  class Repository
+    attr_accessor :org, :repo, :ref, :server
+
+    # ManageIQ::CrossRepo::Repository
+    #
+    # #initialize(identifier, server: "https://github.com")
+    #
+    # identifier can be [org/]repo[@ref]
+    def initialize(identifier, server: "https://github.com")
+      name, ref = identifier.split("@")
+      org, repo = name.split("/")
+      if repo.nil?
+        repo = org
+        org = "ManageIQ"
+      end
+
+      self.server = server
+      self.org = org
+      self.repo = repo
+      self.ref = ref || "master"
+    end
+
+    def name
+      "#{org}/#{repo}"
+    end
+
+    def url
+      File.join(server, org, repo, "tarball", ref)
+    end
+
+    def dir
+      REPOS_DIR.join(name)
+    end
+  end
+end

--- a/lib/manageiq/cross_repo/test_base.rb
+++ b/lib/manageiq/cross_repo/test_base.rb
@@ -1,0 +1,30 @@
+require "manageiq/cross_repo/repository"
+
+module ManageIQ::CrossRepo
+  class TestBase
+    protected
+
+    def system!(*args)
+      exit($CHILD_STATUS.exitstatus) unless system(*args)
+    end
+
+    def ensure_repo(repo)
+      return if repo.path.exist? # TODO: Temporary so it doesn't keep recopying during development
+
+      require "minitar"
+      require "open-uri"
+      require "tmpdir"
+      require "zlib"
+
+      puts "Fetching #{repo.url}"
+
+      Dir.mktmpdir do |dir|
+        Minitar.unpack(Zlib::GzipReader.new(open(repo.url, "rb")), dir)
+
+        content_dir = File.join(dir, Dir.children(dir).detect { |d| d != "pax_global_header" })
+        FileUtils.mkdir_p(repo.path.dirname)
+        FileUtils.mv(content_dir, repo.path)
+      end
+    end
+  end
+end

--- a/lib/manageiq/cross_repo/test_core.rb
+++ b/lib/manageiq/cross_repo/test_core.rb
@@ -1,0 +1,29 @@
+module ManageIQ::CrossRepo
+  class TestCore < TestBase
+    attr_reader :core_repo, :plugin_repos
+
+    def initialize(core_repo, plugin_repos)
+      @core_repo = Repository.new(core_repo)
+      @plugin_repos = plugin_repos.to_a.map { |repo| Repository.new(repo) }
+    end
+
+    def run
+      ensure_repo(core_repo)
+      plugin_repos.each { |plugin_repo| ensure_repo(plugin_repo) }
+
+      File.write(core_repo.path.join("bundler.d", "overrides.rb"),
+        plugin_repos.map { |plugin| "override_gem \"#{plugin.repo}\", :path => \"#{plugin.path}\"" }.join("\n")
+      ) unless plugin_repos.empty?
+
+      Dir.chdir(core_repo.path) do
+        require_relative core_repo.path.join("lib", "manageiq", "environment").to_s
+        ManageIQ::Environment.create_database_user if ENV["CI"]
+        require "bundler"
+        Bundler.with_clean_env do
+          system!("bin/setup")
+          system!("bundle exec rake")
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/cross_repo/test_core.rb
+++ b/lib/manageiq/cross_repo/test_core.rb
@@ -11,9 +11,8 @@ module ManageIQ::CrossRepo
       ensure_repo(core_repo)
       gem_repos.each { |gem_repo| ensure_repo(gem_repo) }
 
-      File.write(core_repo.path.join("bundler.d", "overrides.rb"),
-        gem_repos.map { |gem| "override_gem \"#{gem.repo}\", :path => \"#{gem.path}\"" }.join("\n")
-      ) unless gem_repos.empty?
+      content = gem_repos.map { |gem| "override_gem \"#{gem.repo}\", :path => \"#{gem.path}\"" }.join("\n")
+      File.write(core_repo.path.join("bundler.d", "overrides.rb"), content)
 
       Dir.chdir(core_repo.path) do
         require_relative core_repo.path.join("lib", "manageiq", "environment").to_s

--- a/lib/manageiq/cross_repo/test_core.rb
+++ b/lib/manageiq/cross_repo/test_core.rb
@@ -17,9 +17,8 @@ module ManageIQ::CrossRepo
       File.write(core_repo.path.join("bundler.d", "overrides.rb"), content)
 
       Dir.chdir(core_repo.path) do
-        require_relative core_repo.path.join("lib", "manageiq", "environment").to_s
-        ManageIQ::Environment.create_database_user if ENV["CI"]
         Bundler.with_clean_env do
+          system!({"TRAVIS_BUILD_DIR" => core_repo.path.to_s}, "bash", "tools/ci/before_install.sh") if ENV["CI"]
           system!("bin/setup")
           system!("bundle exec rake")
         end

--- a/lib/manageiq/cross_repo/test_core.rb
+++ b/lib/manageiq/cross_repo/test_core.rb
@@ -1,19 +1,19 @@
 module ManageIQ::CrossRepo
   class TestCore < TestBase
-    attr_reader :core_repo, :plugin_repos
+    attr_reader :core_repo, :gem_repos
 
-    def initialize(core_repo, plugin_repos)
+    def initialize(core_repo, gem_repos)
       @core_repo = Repository.new(core_repo)
-      @plugin_repos = plugin_repos.to_a.map { |repo| Repository.new(repo) }
+      @gem_repos = gem_repos.to_a.map { |repo| Repository.new(repo) }
     end
 
     def run
       ensure_repo(core_repo)
-      plugin_repos.each { |plugin_repo| ensure_repo(plugin_repo) }
+      gem_repos.each { |gem_repo| ensure_repo(gem_repo) }
 
       File.write(core_repo.path.join("bundler.d", "overrides.rb"),
-        plugin_repos.map { |plugin| "override_gem \"#{plugin.repo}\", :path => \"#{plugin.path}\"" }.join("\n")
-      ) unless plugin_repos.empty?
+        gem_repos.map { |gem| "override_gem \"#{gem.repo}\", :path => \"#{gem.path}\"" }.join("\n")
+      ) unless gem_repos.empty?
 
       Dir.chdir(core_repo.path) do
         require_relative core_repo.path.join("lib", "manageiq", "environment").to_s

--- a/lib/manageiq/cross_repo/test_core.rb
+++ b/lib/manageiq/cross_repo/test_core.rb
@@ -3,6 +3,8 @@ module ManageIQ::CrossRepo
     attr_reader :core_repo, :gem_repos
 
     def initialize(core_repo, gem_repos)
+      raise ArgumentError, "You must pass at least one gem to override" if gem_repos.to_a.empty?
+
       @core_repo = Repository.new(core_repo)
       @gem_repos = gem_repos.to_a.map { |repo| Repository.new(repo) }
     end
@@ -17,7 +19,6 @@ module ManageIQ::CrossRepo
       Dir.chdir(core_repo.path) do
         require_relative core_repo.path.join("lib", "manageiq", "environment").to_s
         ManageIQ::Environment.create_database_user if ENV["CI"]
-        require "bundler"
         Bundler.with_clean_env do
           system!("bin/setup")
           system!("bundle exec rake")

--- a/lib/manageiq/cross_repo/test_plugin.rb
+++ b/lib/manageiq/cross_repo/test_plugin.rb
@@ -15,7 +15,6 @@ module ManageIQ::CrossRepo
       FileUtils.ln_s(core_repo.path, plugin_repo.path.join("spec", "manageiq"), :force => true)
 
       Dir.chdir(plugin_repo.path) do
-        require "bundler"
         Bundler.with_clean_env do
           system!("bin/setup")
           system!("bundle exec rake spec")

--- a/lib/manageiq/cross_repo/test_plugin.rb
+++ b/lib/manageiq/cross_repo/test_plugin.rb
@@ -1,51 +1,25 @@
 require "manageiq/cross_repo/repository"
 
 module ManageIQ::CrossRepo
-  class TestPlugin
+  class TestPlugin < TestBase
     attr_reader :plugin_repo, :core_repo
 
-    def initialize(repo_name, core_ref)
-      @core_repo = Repository.new("manageiq")
-      @core_repo.ref = core_ref if core_ref
-      @plugin_repo = Repository.new(repo_name)
+    def initialize(plugin_repo, core_repo)
+      @core_repo = Repository.new(core_repo)
+      @plugin_repo = Repository.new(plugin_repo)
     end
 
     def run
       ensure_repo(plugin_repo)
       ensure_repo(core_repo)
-      FileUtils.ln_s(core_repo.dir, plugin_repo.dir.join("spec", "manageiq"), :force => true)
+      FileUtils.ln_s(core_repo.path, plugin_repo.path.join("spec", "manageiq"), :force => true)
 
-      Dir.chdir(plugin_repo.dir) do
+      Dir.chdir(plugin_repo.path) do
         require "bundler"
         Bundler.with_clean_env do
           system!("bin/setup")
           system!("bundle exec rake spec")
         end
-      end
-    end
-
-    private
-
-    def system!(*args)
-      exit($CHILD_STATUS.exitstatus) unless system(*args)
-    end
-
-    def ensure_repo(repo)
-      return if repo.dir.exist? # TODO: Temporary so it doesn't keep recopying during development
-
-      require "minitar"
-      require "open-uri"
-      require "tmpdir"
-      require "zlib"
-
-      puts "Fetching #{repo.url}"
-
-      Dir.mktmpdir do |dir|
-        Minitar.unpack(Zlib::GzipReader.new(open(repo.url, "rb")), dir)
-
-        content_dir = File.join(dir, Dir.children(dir).detect { |d| d != "pax_global_header" })
-        FileUtils.mkdir_p(repo.dir.dirname)
-        FileUtils.mv(content_dir, repo.dir)
       end
     end
   end


### PR DESCRIPTION
This adds a task to run the core tests with a specific version of manageiq core as well as a specific set of plugins to override with.  Both core and the plugins can be specified by `[org/|ManageIQ]repo-name[@ref|master]`.