### PR TITLE
Add support for GEM_REPOS to test:plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ To test a specific plugin branch against a particular ManageIQ SHA
 TEST_REPO=manageiq-ui-classic@branch-name MANAGEIQ_CORE_REF=1234abcd bundle exec rake test:plugin
 ```
 
+To test a specific plugin branch with a particular ManageIQ SHA and a set of other plugins
+
+```ruby
+TEST_REPO=manageiq-ui-classic@feature MANAGEIQ_CORE_REF=1234abcd GEM_REPOS=manageiq-providers-vmware@feature,manageiq-providers-amazon@feature
+```
+
 To run the core tests with ManageIQ master using a specific gem version
 
 ```ruby

--- a/Rakefile
+++ b/Rakefile
@@ -26,12 +26,14 @@ namespace :test do
   task :plugin do
     test_repo = ENV["TEST_REPO"]
     core_ref  = ENV["MANAGEIQ_CORE_REF"] || "master"
+    gem_repos = ENV["GEM_REPOS"]&.split(",")
+
     if test_repo.blank? || core_ref.blank?
       STDERR.puts "ERROR: TEST_REPO env var must be specfied" if test_repo.blank?
       STDERR.puts "ERROR: CORE_REF env var must be specfied"  if core_ref.blank?
       exit 1
     end
 
-    ManageIQ::CrossRepo::TestPlugin.new(test_repo, "manageiq@#{core_ref}").run
+    ManageIQ::CrossRepo::TestPlugin.new(test_repo, "manageiq@#{core_ref}", gem_repos).run
   end
 end

--- a/lib/manageiq/cross_repo/test_base.rb
+++ b/lib/manageiq/cross_repo/test_base.rb
@@ -26,5 +26,15 @@ module ManageIQ::CrossRepo
         FileUtils.mv(content_dir, repo.path)
       end
     end
+
+    def generate_bundler_d(gem_repos, test_repo)
+      content = gem_repos.map { |gem| "override_gem \"#{gem.repo}\", :path => \"#{gem.path}\"" }.join("\n")
+      File.write(test_repo.path.join("bundler.d", "overrides.rb"), content)
+    end
+
+    def prepare_gem_repos(gem_repos, test_repo)
+      gem_repos.each { |gem_repo| ensure_repo(gem_repo) }
+      generate_bundler_d(gem_repos, test_repo)
+    end
   end
 end

--- a/lib/manageiq/cross_repo/test_core.rb
+++ b/lib/manageiq/cross_repo/test_core.rb
@@ -11,10 +11,7 @@ module ManageIQ::CrossRepo
 
     def run
       ensure_repo(core_repo)
-      gem_repos.each { |gem_repo| ensure_repo(gem_repo) }
-
-      content = gem_repos.map { |gem| "override_gem \"#{gem.repo}\", :path => \"#{gem.path}\"" }.join("\n")
-      File.write(core_repo.path.join("bundler.d", "overrides.rb"), content)
+      prepare_gem_repos(gem_repos, core_repo)
 
       Dir.chdir(core_repo.path) do
         Bundler.with_clean_env do

--- a/lib/manageiq/cross_repo/test_plugin.rb
+++ b/lib/manageiq/cross_repo/test_plugin.rb
@@ -2,16 +2,19 @@ require "manageiq/cross_repo/repository"
 
 module ManageIQ::CrossRepo
   class TestPlugin < TestBase
-    attr_reader :plugin_repo, :core_repo
+    attr_reader :plugin_repo, :core_repo, :gem_repos
 
-    def initialize(plugin_repo, core_repo)
+    def initialize(plugin_repo, core_repo, gem_repos)
       @core_repo = Repository.new(core_repo)
       @plugin_repo = Repository.new(plugin_repo)
+      @gem_repos = gem_repos.to_a.map { |repo| Repository.new(repo) }
     end
 
     def run
       ensure_repo(plugin_repo)
       ensure_repo(core_repo)
+      prepare_gem_repos(gem_repos, plugin_repo)
+
       FileUtils.ln_s(core_repo.path, plugin_repo.path.join("spec", "manageiq"), :force => true)
 
       Dir.chdir(plugin_repo.path) do


### PR DESCRIPTION
Allow a set of GEM_REPOS to be passed to the rake test:plugin method