### PR TITLE
Improve repo cache management

### DIFF
--- a/lib/manageiq/cross_repo/repository.rb
+++ b/lib/manageiq/cross_repo/repository.rb
@@ -34,5 +34,24 @@ module ManageIQ::CrossRepo
     def core?
       repo.casecmp("manageiq") == 0
     end
+
+    def ensure_clone
+      return if path.exist? # TODO: Temporary so it doesn't keep recopying during development
+
+      require "minitar"
+      require "open-uri"
+      require "tmpdir"
+      require "zlib"
+
+      puts "Fetching #{url}"
+
+      Dir.mktmpdir do |dir|
+        Minitar.unpack(Zlib::GzipReader.new(open(url, "rb")), dir)
+
+        content_dir = File.join(dir, Dir.children(dir).detect { |d| d != "pax_global_header" })
+        FileUtils.mkdir_p(path.dirname)
+        FileUtils.mv(content_dir, path)
+      end
+    end
   end
 end

--- a/lib/manageiq/cross_repo/repository.rb
+++ b/lib/manageiq/cross_repo/repository.rb
@@ -1,6 +1,6 @@
 module ManageIQ::CrossRepo
   class Repository
-    attr_accessor :org, :repo, :ref, :server
+    attr_accessor :org, :repo, :ref, :server, :sha
 
     # ManageIQ::CrossRepo::Repository
     #
@@ -17,6 +17,7 @@ module ManageIQ::CrossRepo
       self.org    = org
       self.repo   = repo
       self.ref    = ref || "master"
+      self.sha    = ref_to_sha(@ref)
     end
 
     def name
@@ -24,11 +25,15 @@ module ManageIQ::CrossRepo
     end
 
     def url
-      File.join(server, org, repo, "tarball", ref)
+      File.join(server, org, repo)
+    end
+
+    def tarball_url
+      File.join(url, "tarball", ref)
     end
 
     def path
-      REPOS_DIR.join(name)
+      REPOS_DIR.join("#{name}@#{sha}")
     end
 
     def core?
@@ -36,22 +41,28 @@ module ManageIQ::CrossRepo
     end
 
     def ensure_clone
-      return if path.exist? # TODO: Temporary so it doesn't keep recopying during development
+      return if path.exist?
 
       require "minitar"
       require "open-uri"
       require "tmpdir"
       require "zlib"
 
-      puts "Fetching #{url}"
+      puts "Fetching #{tarball_url}"
 
       Dir.mktmpdir do |dir|
-        Minitar.unpack(Zlib::GzipReader.new(open(url, "rb")), dir)
+        Minitar.unpack(Zlib::GzipReader.new(open(tarball_url, "rb")), dir)
 
         content_dir = File.join(dir, Dir.children(dir).detect { |d| d != "pax_global_header" })
         FileUtils.mkdir_p(path.dirname)
         FileUtils.mv(content_dir, path)
       end
+    end
+
+    private
+
+    def ref_to_sha(ref)
+      ref.match?(/^\h+$/) ? ref : `git ls-remote #{url} #{ref}`.split("\t").first
     end
   end
 end

--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -23,14 +23,14 @@ module ManageIQ::CrossRepo
 
     def run
       test_repo.ensure_clone
-      prepare_gem_repos
-
       test_repo.core? ? run_core : run_plugin
     end
 
     private
 
     def run_core
+      prepare_gem_repos
+
       with_test_env do
         system!({"TRAVIS_BUILD_DIR" => test_repo.path.to_s}, "bash", "tools/ci/before_install.sh") if ENV["CI"]
         system!("bin/setup")
@@ -41,6 +41,8 @@ module ManageIQ::CrossRepo
     def run_plugin
       core_repo.ensure_clone
       FileUtils.ln_s(core_repo.path, test_repo.path.join("spec", "manageiq"), :force => true)
+
+      prepare_gem_repos
 
       with_test_env do
         system!("bin/setup")

--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -22,7 +22,7 @@ module ManageIQ::CrossRepo
     end
 
     def run
-      ensure_repo(test_repo)
+      test_repo.ensure_clone
       prepare_gem_repos
 
       test_repo.core? ? run_core : run_plugin
@@ -39,7 +39,7 @@ module ManageIQ::CrossRepo
     end
 
     def run_plugin
-      ensure_repo(core_repo)
+      core_repo.ensure_clone
       FileUtils.ln_s(core_repo.path, test_repo.path.join("spec", "manageiq"), :force => true)
 
       with_test_env do
@@ -60,25 +60,6 @@ module ManageIQ::CrossRepo
       exit($CHILD_STATUS.exitstatus) unless system(*args)
     end
 
-    def ensure_repo(repo)
-      return if repo.path.exist? # TODO: Temporary so it doesn't keep recopying during development
-
-      require "minitar"
-      require "open-uri"
-      require "tmpdir"
-      require "zlib"
-
-      puts "Fetching #{repo.url}"
-
-      Dir.mktmpdir do |dir|
-        Minitar.unpack(Zlib::GzipReader.new(open(repo.url, "rb")), dir)
-
-        content_dir = File.join(dir, Dir.children(dir).detect { |d| d != "pax_global_header" })
-        FileUtils.mkdir_p(repo.path.dirname)
-        FileUtils.mv(content_dir, repo.path)
-      end
-    end
-
     def generate_bundler_d
       bundler_d_path = core_repo.path.join("bundler.d")
       override_path  = bundler_d_path.join("overrides.rb")
@@ -94,7 +75,7 @@ module ManageIQ::CrossRepo
     end
 
     def prepare_gem_repos
-      gem_repos.each { |gem_repo| ensure_repo(gem_repo) }
+      gem_repos.each { |gem_repo| gem_repo.ensure_clone }
       generate_bundler_d
     end
   end


### PR DESCRIPTION
If a user passes a branch name e.g. master then update the cached repos when newer refs are added.