### PR TITLE
Repository.sha is now set in all cases, not ref

### DIFF
--- a/lib/manageiq/cross_repo/repository.rb
+++ b/lib/manageiq/cross_repo/repository.rb
@@ -81,7 +81,7 @@ module ManageIQ::CrossRepo
     end
 
     def tarball_url
-      url && File.join(url, "tarball", ref)
+      url && File.join(url, "tarball", sha)
     end
   end
 end


### PR DESCRIPTION
If you pass a PR then ref is never set because we set sha.  This was
causing tarball_url to throw an exception if you passed the repo in PR
form.