### PR TITLE
Default to fast_finish when a matrix is present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ cache:
   bundler: true
 addons:
   postgresql: '10'
+matrix:
+  fast_finish: true
 env:
   global:
   - TEST_REPO=


### PR DESCRIPTION
@agrare Please review.

If multiple repos are passed and one fails, we can fail the entire travis run.