### PR TITLE
Mixlib::Archive has better archive format support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ plugin 'bundler-inject'
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
 
 gem "activesupport"
-gem "minitar"
+gem "mixlib-archive"
 gem "rake"
 
 group :development, :test do

--- a/lib/manageiq/cross_repo/repository.rb
+++ b/lib/manageiq/cross_repo/repository.rb
@@ -29,7 +29,7 @@ module ManageIQ::CrossRepo
       Dir.mktmpdir do |dir|
         Minitar.unpack(Zlib::GzipReader.new(open(tarball_url, "rb")), dir)
 
-        content_dir = File.join(dir, Pathname.new(dir).children.detect(&:directory?))
+        content_dir = Pathname.new(dir).children.detect(&:directory?)
         FileUtils.mkdir_p(path.dirname)
         FileUtils.mv(content_dir, path)
       end

--- a/lib/manageiq/cross_repo/repository.rb
+++ b/lib/manageiq/cross_repo/repository.rb
@@ -19,7 +19,7 @@ module ManageIQ::CrossRepo
     def ensure_clone
       return if path.exist?
 
-      require "minitar"
+      require "mixlib/archive"
       require "open-uri"
       require "tmpdir"
       require "zlib"
@@ -27,7 +27,7 @@ module ManageIQ::CrossRepo
       puts "Fetching #{tarball_url}"
 
       Dir.mktmpdir do |dir|
-        Minitar.unpack(Zlib::GzipReader.new(open(tarball_url, "rb")), dir)
+        Mixlib::Archive.new(open(tarball_url, "rb")).extract(dir)
 
         content_dir = Pathname.new(dir).children.detect(&:directory?)
         FileUtils.mkdir_p(path.dirname)


### PR DESCRIPTION
Minitar only supports POSIX tar and not the newer pax extensions.