### PR TITLE
Support commit and branch url formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Repo Formats:
     @ref:       Optional, defaults to master if #pr not set. Can be a branch, tag, or SHA. Mutually exclusive with #pr.
     #pr:        Optional, references a pull-request number. Mutually exclusive with @ref.
 
+  URL: https://github.com/org/repository, https://github.com/org/repository/tree/branch,
+       https://github.com/org/repository/commit/sha, https://github.com/org/repository/pull/pr
+
   Local: Either a fully qualified path or a relative path (e.g. /path/to/repo, ~/relative/to/home, ../relative/to/current/dir)
 
 Examples:

--- a/exe/manageiq-cross_repo
+++ b/exe/manageiq-cross_repo
@@ -49,6 +49,9 @@ opts = Optimist.options do
         @ref:       Optional, defaults to master if #pr not set. Can be a branch, tag, or SHA. Mutually exclusive with #pr.
         #pr:        Optional, references a pull-request number. Mutually exclusive with @ref.
 
+      URL: https://github.com/org/repository, https://github.com/org/repository/tree/branch,
+           https://github.com/org/repository/commit/sha, https://github.com/org/repository/pull/pr
+
       Local: Either a fully qualified path or a relative path (e.g. /path/to/repo, ~/relative/to/home, ../relative/to/current/dir)
   EOS
 

--- a/spec/manageiq/cross_repo/repository_spec.rb
+++ b/spec/manageiq/cross_repo/repository_spec.rb
@@ -45,6 +45,12 @@ describe ManageIQ::CrossRepo::Repository do
           expect(repo.path).to eq(ManageIQ::CrossRepo::REPOS_DIR.join("JoeSmith", "manageiq@#{sha}"))
         end
 
+        it "in a URL format" do
+          repo = described_class.new("https://github.com/JoeSmith/manageiq/tree/#{branch}")
+
+          expect(repo.path).to eq(ManageIQ::CrossRepo::REPOS_DIR.join("JoeSmith", "manageiq@#{sha}"))
+        end
+
         context "that doesn't exist" do
           let(:sha) { nil }
 
@@ -59,6 +65,12 @@ describe ManageIQ::CrossRepo::Repository do
     context "with a specific ref" do
       it "uses the ref" do
         repo = described_class.new("manageiq@#{sha}")
+
+        expect(repo.path).to eq(ManageIQ::CrossRepo::REPOS_DIR.join("ManageIQ", "manageiq@#{sha}"))
+      end
+
+      it "in a URL format" do
+        repo = described_class.new("https://github.com/ManageIQ/manageiq/commit/#{sha}")
 
         expect(repo.path).to eq(ManageIQ::CrossRepo::REPOS_DIR.join("ManageIQ", "manageiq@#{sha}"))
       end


### PR DESCRIPTION
Add support for URLs representing branches (with /tree/branch) and
direct commits (with /commit/sha).