### PR TITLE
Fix indirect gem overrides

### DIFF
--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -68,7 +68,7 @@ module ManageIQ::CrossRepo
       if gem_repos.empty?
         FileUtils.rm_f override_path
       else
-        content = gem_repos.map { |gem| "override_gem \"#{gem.repo}\", :path => \"#{gem.path}\"" }.join("\n")
+        content = gem_repos.map { |gem| "ensure_gem \"#{gem.repo}\", :path => \"#{gem.path}\"" }.join("\n")
         FileUtils.mkdir_p(bundler_d_path)
 
         File.write(override_path, content)


### PR DESCRIPTION
If a gem isn't directly referenced in the core-repo's gemfile it cannot
be overridden, ensure_gem has to be used.

Fixes https://github.com/ManageIQ/manageiq-cross_repo/issues/36