### PR TITLE
Allow test_repo and core_repo to be present if they match

### DIFF
--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -8,7 +8,7 @@ module ManageIQ::CrossRepo
     def initialize(test_repo, core_repo, gem_repos)
       @test_repo = Repository.new(test_repo || "ManageIQ/manageiq@master")
       if @test_repo.core?
-        raise ArgumentError, "You cannot pass core repo when running a core test"           if core_repo.present?
+        raise ArgumentError, "You cannot pass core repo when running a core test"           if core_repo.present? && core_repo != test_repo
         raise ArgumentError, "You must pass at least one gem repo when running a core test" if gem_repos.blank?
 
         @core_repo = @test_repo


### PR DESCRIPTION
Allow the user to pass both a core_repo and a test_repo as long as they
match, this simplifies running a matrix of tests with the same core_repo