### PR TITLE
Add ffi-libarchive so we can extract long filenames

### DIFF
--- a/manageiq-cross_repo.gemspec
+++ b/manageiq-cross_repo.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
 
   spec.add_dependency "activesupport"
+  spec.add_dependency "ffi-libarchive"
   spec.add_dependency "mixlib-archive"
   spec.add_dependency "optimist"
 end


### PR DESCRIPTION
The `Mixlib::Archive::Tar` class doesn't support extracting long filenames so you end up with:
```
/tmp/d20191025-14073-7imeua:
total 20
-rw-rw-r-- 1 adam grare 1266 Oct 25 10:45 06dc14461eea3bce1e476468bd5962f2412bf7e1.data
-rw-rw-r-- 1 adam grare  373 Oct 25 10:45 43c5be13b2b08319da22d8cf2058434b965398d1.data
-rw-rw-r-- 1 adam grare 1116 Oct 25 10:45 c42f0b538642ba614986a8045e108de8cc98614d.data
-rw-rw-r-- 1 adam grare  304 Oct 25 10:45 cb192bf901ee1a65773f5b807f69a4db005ad592.data
-rw-rw-r-- 1 adam grare 1886 Oct 25 10:45 de74145bb14b505f5a375172acc380d8af8487aa.data
drwxrwxr-x 1 adam grare  376 Oct 25 10:45 ManageIQ-manageiq-schema-3d56317
```

Switching to `Mixlib::Archive::LibArchiver` fixes this but requires the `ffi-libarchive` gem