### PR TITLE
Let the plugins symlink spec/manageiq if they need

### DIFF
--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -40,7 +40,6 @@ module ManageIQ::CrossRepo
 
     def run_plugin
       core_repo.ensure_clone
-      cleanup_core_repo_symlink
       prepare_gem_repos
 
       env_vars = {"MANAGEIQ_REPO" => core_repo.path.to_s}
@@ -83,10 +82,6 @@ module ManageIQ::CrossRepo
     def prepare_gem_repos
       gem_repos.each { |gem_repo| gem_repo.ensure_clone }
       generate_bundler_d
-    end
-
-    def cleanup_core_repo_symlink
-      FileUtils.rm_f(test_repo.path.join("spec", "manageiq"))
     end
   end
 end

--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -40,11 +40,12 @@ module ManageIQ::CrossRepo
 
     def run_plugin
       core_repo.ensure_clone
-      symlink_core_repo_spec
+      cleanup_core_repo_symlink
       prepare_gem_repos
 
+      env_vars = {"MANAGEIQ_REPO" => core_repo.path.to_s}
       with_test_env do
-        system!("bin/setup")
+        system!(env_vars, "bin/setup")
         system!("bundle exec rake")
       end
     end
@@ -84,10 +85,8 @@ module ManageIQ::CrossRepo
       generate_bundler_d
     end
 
-    def symlink_core_repo_spec
-      core_spec_symlink = test_repo.path.join("spec", "manageiq")
-      FileUtils.rm_f(core_spec_symlink)
-      FileUtils.ln_s(core_repo.path, core_spec_symlink)
+    def cleanup_core_repo_symlink
+      FileUtils.rm_f(test_repo.path.join("spec", "manageiq"))
     end
   end
 end


### PR DESCRIPTION
Pass a MANAGEIQ_REPO env var when running bin/setup in the plugins if
they need to link to the core repo.

Plugin repo changes:

- [x] https://github.com/ManageIQ/manageiq/pull/19481

- [x] https://github.com/ManageIQ/manageiq-providers-ovirt/pull/426

- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/6390

- [x] https://github.com/ManageIQ/manageiq-providers-azure/pull/363

- [x] https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/155

- [x] https://github.com/ManageIQ/manageiq-providers-openstack/pull/528

- [x] https://github.com/ManageIQ/manageiq-decorators/pull/24

- [x] https://github.com/ManageIQ/manageiq-providers-vmware/pull/474

- [x] https://github.com/ManageIQ/manageiq-providers-azure_stack/pull/20

- [x] https://github.com/ManageIQ/manageiq-providers-google/pull/115

- [x] https://github.com/ManageIQ/manageiq-content/pull/608

- [x] https://github.com/ManageIQ/manageiq-consumption/pull/171

- [x] https://github.com/ManageIQ/manageiq-providers-ansible_tower/pull/205

- [x] https://github.com/ManageIQ/manageiq-providers-scvmm/pull/142

- [x] https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/347

- [x] https://github.com/ManageIQ/manageiq-automation_engine/pull/389

- [x] https://github.com/ManageIQ/manageiq-providers-nuage/pull/193

- [x] https://github.com/ManageIQ/manageiq-api/pull/703

- [x] https://github.com/ManageIQ/manageiq-providers-dummy_provider/pull/20

- [x] https://github.com/ManageIQ/manageiq-providers-lenovo/pull/286

- [x] https://github.com/ManageIQ/manageiq-graphql/pull/84

- [x] https://github.com/ManageIQ/manageiq-providers-openshift/pull/153

- [x] https://github.com/ManageIQ/manageiq-providers-redfish/pull/98

- [x] https://github.com/ManageIQ/manageiq-providers-foreman/pull/51

- [ ] https://github.com/ManageIQ/manageiq-providers-amazon/pull/570