### PR TITLE
Fix an error when running the gem binary standlone

### DIFF
--- a/exe/manageiq-cross_repo
+++ b/exe/manageiq-cross_repo
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require "bundler"
 require "bundler/setup"
 
 require "manageiq-cross_repo"

--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -51,7 +51,6 @@ module ManageIQ::CrossRepo
 
     def with_test_env
       Dir.chdir(test_repo.path) do
-        require "bundler"
         Bundler.with_clean_env do
           yield
         end

--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -51,6 +51,7 @@ module ManageIQ::CrossRepo
 
     def with_test_env
       Dir.chdir(test_repo.path) do
+        require "bundler"
         Bundler.with_clean_env do
           yield
         end


### PR DESCRIPTION
When running the manageiq-cross_repo binary from the installed gem
bundler isn't automatically required which leads to:

```
$ manageiq-cross_repo --test-repo manageiq-ui-classic --core-repo ../manageiq
Traceback (most recent call last):
	8: from /home/agrare/.gem/bin/manageiq-cross_repo:23:in `<main>'
	7: from /home/agrare/.gem/bin/manageiq-cross_repo:23:in `load'
	6: from /home/agrare/.gem/gems/manageiq-cross_repo-0.3.0/exe/manageiq-cross_repo:98:in `<top (required)>'
	5: from /home/agrare/.gem/gems/manageiq-cross_repo-0.3.0/lib/manageiq/cross_repo.rb:11:in `run'
	4: from /home/agrare/.gem/gems/manageiq-cross_repo-0.3.0/lib/manageiq/cross_repo/runner.rb:26:in `run'
	3: from /home/agrare/.gem/gems/manageiq-cross_repo-0.3.0/lib/manageiq/cross_repo/runner.rb:46:in `run_plugin'
	2: from /home/agrare/.gem/gems/manageiq-cross_repo-0.3.0/lib/manageiq/cross_repo/runner.rb:53:in `with_test_env'
	1: from /home/agrare/.gem/gems/manageiq-cross_repo-0.3.0/lib/manageiq/cross_repo/runner.rb:53:in `chdir'
/home/agrare/.gem/gems/manageiq-cross_repo-0.3.0/lib/manageiq/cross_repo/runner.rb:54:in `block in with_test_env': undefined method `with_clean_env' for Bundler:Module (NoMethodError)
```