### PR TITLE
Cleanup the sample env vars from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,3 @@ addons:
     - libarchive-dev
 matrix:
   fast_finish: true
-env:
-  global:
-  - TEST_REPO=
-  - CORE_REPO=
-  - GEM_REPOS=


### PR DESCRIPTION
Now that we aren't using this repo to run actual cross_repo tests we
don't need the example env vars in the .travis.yml