### PR TITLE
Implement == for Repository objects

### DIFF
--- a/lib/manageiq/cross_repo/repository.rb
+++ b/lib/manageiq/cross_repo/repository.rb
@@ -19,6 +19,10 @@ module ManageIQ::CrossRepo
       repo.casecmp("manageiq") == 0
     end
 
+    def ==(other)
+      repo == other.repo && sha == other.sha
+    end
+
     def ensure_clone
       return if path.exist?
 

--- a/spec/manageiq/cross_repo/repository_spec.rb
+++ b/spec/manageiq/cross_repo/repository_spec.rb
@@ -13,7 +13,7 @@ describe ManageIQ::CrossRepo::Repository do
         it "sets the proper defaults" do
           repo = described_class.new("manageiq")
 
-          expect(repo.org).to eq("ManageIQ")
+          expect(repo.org).to  eq("ManageIQ")
           expect(repo.repo).to eq("manageiq")
           expect(repo.sha).to  eq(sha)
           expect(repo.url).to  eq("https://github.com/ManageIQ/manageiq")
@@ -112,6 +112,29 @@ describe ManageIQ::CrossRepo::Repository do
 
     it "with a plugin repo" do
       expect(described_class.new("manageiq-providers-amazon").core?).to be_falsy
+    end
+  end
+
+  context "#==" do
+    it "with the same identifier is equal" do
+      repo1 = described_class.new("manageiq@#{sha}")
+      repo2 = described_class.new("manageiq@#{sha}")
+
+      expect(repo1).to eq(repo2)
+    end
+
+    it "with different identifiers is not equal" do
+      repo1 = described_class.new("manageiq@#{sha}")
+      repo2 = described_class.new("manageiq-ui-classic@9ce90e18be2fc2d0fd864d89c09790bd9d4b45bb")
+
+      expect(repo1).not_to eq(repo2)
+    end
+
+    it "the same repo and sha in different orgs is equal" do
+      repo1 = described_class.new("manageiq@#{sha}")
+      repo2 = described_class.new("JohnDoe/manageiq@#{sha}")
+
+      expect(repo1).to eq(repo2)
     end
   end
 


### PR DESCRIPTION
Allow for more flexible equality checking of Repository objects.

By comparing the repository and sha we can more reliably check equality
compared to just repo identifier string comparison.  For example the
same commit in ManageIQ and a fork would not be equal if we were just
checking "ManageIQ/manageiq@master" and "JoeSmith/manageiq@master" but
by checking the repo+sha they would.