### PR TITLE
Support multiple space-separated values in REPOS env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,10 @@ Examples:
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).
+
+## Running on Travis
+
+This tool executes the tests locally.
+
+Frequently it's easier and more useful to run on Travis, where the test results can be shared with other developers/reviewers.
+That's possible by opening a PR to https://github.com/ManageIQ/manageiq-cross_repo-tests repo.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Options:
   -r, --repos=<s+>        Optional, a list of other repos and/or gems to override while running the tests.
                           If any of the repositories in the list are a core repository that will
                           be used as the root repository, otherwise ManageIQ/manageiq@master will be the default.
-                          Can also be passed as a REPOS environment variable.
+                          Can also be passed as a REPOS environment variable, space-separated.
 
   -v, --version           Print version and exit
   -h, --help              Show this message
@@ -53,6 +53,8 @@ Examples:
 
   # Test a plugin branch with a ManageIQ SHA and a set of other plugins
   manageiq-cross_repo --test-repo manageiq-ui-classic@feature --repos manageiq@1234abcd manageiq-providers-vmware@feature manageiq-content@feature
+  # or equivalently:
+  env TEST_REPO=manageiq-ui-classic@feature REPOS='manageiq@1234abcd manageiq-providers-vmware@feature manageiq-content@feature' manageiq-cross_repo
 
   # Run core tests with ManageIQ master using a gem version
   manageiq-cross_repo --repos johndoe/manageiq-ui-classic@feature

--- a/exe/manageiq-cross_repo
+++ b/exe/manageiq-cross_repo
@@ -24,7 +24,7 @@ opts = Optimist.options do
     Can also be passed as a TEST_REPO environment variable.
   EOS
 
-  opt :repos, <<~EOS, :type => :strings, :default => ENV["REPOS"] || "").split
+  opt :repos, <<~EOS, :type => :strings, :default => (ENV["REPOS"] || "").split
     Optional, a list of other repos and/or gems to override while running the tests.
     If any of the repositories in the list are a core repository that will
     be used as the root repository, otherwise ManageIQ/manageiq@master will be the default.

--- a/exe/manageiq-cross_repo
+++ b/exe/manageiq-cross_repo
@@ -24,11 +24,11 @@ opts = Optimist.options do
     Can also be passed as a TEST_REPO environment variable.
   EOS
 
-  opt :repos, <<~EOS, :type => :strings, :default => Array(ENV["REPOS"].presence)
+  opt :repos, <<~EOS, :type => :strings, :default => ENV["REPOS"] || "").split
     Optional, a list of other repos and/or gems to override while running the tests.
     If any of the repositories in the list are a core repository that will
     be used as the root repository, otherwise ManageIQ/manageiq@master will be the default.
-    Can also be passed as a REPOS environment variable.
+    Can also be passed as a REPOS environment variable, space-separated
   EOS
 
   # Manually add these so they appear in the right order in the help output


### PR DESCRIPTION
Via flags, it's possible to inject multiple `--repos foo@x bar#42`.  
But AFAICT it's currently impossible to do the equivalent via `REPOS` env var, which is what we need for running such tests on Travis via https://github.com/ManageIQ/manageiq-cross_repo-tests.
=> Example failed attempt: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/48, https://travis-ci.org/ManageIQ/manageiq-cross_repo-tests/builds/633213011

This PR allows multiple space-separated values.  If merged I'll later send a followup to add such examples to the -tests repo too.
=> Example attempt with this PR: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/49, https://travis-ci.com/ManageIQ/manageiq-cross_repo-tests/builds/143221514

@agrare @Fryguy please review