### PR TITLE
Get the gem name from the *.gemspec not the repo

### DIFF
--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -73,7 +73,11 @@ module ManageIQ::CrossRepo
       if gem_repos.empty?
         FileUtils.rm_f override_path
       else
-        content = gem_repos.map { |gem| "ensure_gem \"#{gem.repo}\", :path => \"#{gem.path}\"" }.join("\n")
+        content = gem_repos.map do |gem|
+          # If there is a gemspec get the name of the gem from that instead of the repository
+          gem_name = gem.path.glob("*.gemspec")&.first&.basename(".gemspec") || gem.repo
+          "ensure_gem \"#{gem_name}\", :path => \"#{gem.path}\""
+        end.join("\n")
         FileUtils.mkdir_p(bundler_d_path)
 
         File.write(override_path, content)


### PR DESCRIPTION
There are some cases where the name of the gem differs from the name of
the repository.  In these cases it is better to get the gem name for the
overrides.rb file from the name of the gemspec than the repo name.

Fixes https://github.com/ManageIQ/manageiq-cross_repo/issues/56