### PR TITLE
Fix Kernel#open warning downloading repo tarball

### DIFF
--- a/lib/manageiq/cross_repo/repository.rb
+++ b/lib/manageiq/cross_repo/repository.rb
@@ -148,7 +148,7 @@ module ManageIQ::CrossRepo
     end
 
     def open_tarball_url(url)
-      archive = open(tarball_url, "rb")
+      archive = URI.open(tarball_url, "rb")
 
       if archive.kind_of?(StringIO)
         archive = Tempfile.new('cross_repo').tap do |f|


### PR DESCRIPTION
`lib/manageiq/cross_repo/repository.rb:151: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open`