### PR TITLE
Add --script-cmd opt

### DIFF
--- a/exe/manageiq-cross_repo
+++ b/exe/manageiq-cross_repo
@@ -31,6 +31,10 @@ opts = Optimist.options do
     Can also be passed as a REPOS environment variable.
   EOS
 
+  opt :script_cmd, <<~EOS, :type => :string, :default => ENV["SCRIPT_CMD"].presence || ""
+    Optional, a command string for running the specs.  Defaults to `bundle exec rake`.
+  EOS
+
   # Manually add these so they appear in the right order in the help output
   banner ""
   opt :version, "Print version and exit"
@@ -86,7 +90,7 @@ end
 opts[:repos] = opts[:repos].flatten.flat_map { |repo| repo.split(",").map(&:strip) }
 
 begin
-  ManageIQ::CrossRepo.run(opts[:test_repo], opts[:repos])
+  ManageIQ::CrossRepo.run(opts[:test_repo], opts[:repos], opts[:script_cmd])
 rescue ArgumentError => e
   Optimist.die e
 end


### PR DESCRIPTION
Allows configuring a custom script to be executed for running the specs.

In this scenario, if this is specific to a particular `TEST_REPO`, then this will only work with said repo and the user will have to configure the cross repo run for that test in particular, and leave the others as the default.

This should solve the issues I am having in https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/150 by adding the following to the `.travis.yml` for that one:

```diff
   fast_finish: true
 env:
   global:
-  - REPOS=
+  - REPOS=ManageIQ/manageiq/pull/20350,ManageIQ/manageiq-ui-classic/pull/7201
   matrix:
-  - TEST_REPO=manageiq
+  - TEST_REPO=ManageIQ/manageiq-ui-classic/pull/7201 SCRIPT_CMD="bundle exec rake spec:cypress"
```