### PR TITLE
Add --debug flag

### DIFF
--- a/exe/manageiq-cross_repo
+++ b/exe/manageiq-cross_repo
@@ -35,6 +35,8 @@ opts = Optimist.options do
     Optional, a command string for running the specs.  Defaults to `bundle exec rake`.
   EOS
 
+  opt :debug, "Print extra debugging output", :default => ENV["DEBUG"].presence || false
+
   # Manually add these so they appear in the right order in the help output
   banner ""
   opt :version, "Print version and exit"
@@ -90,7 +92,7 @@ end
 opts[:repos] = opts[:repos].flatten.flat_map { |repo| repo.split(",").map(&:strip) }
 
 begin
-  ManageIQ::CrossRepo.run(opts[:test_repo], opts[:repos], opts[:script_cmd])
+  ManageIQ::CrossRepo.run(opts[:test_repo], opts[:repos], opts[:script_cmd], opts[:debug])
 rescue ArgumentError => e
   Optimist.die e
 end

--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -77,6 +77,18 @@ module ManageIQ::CrossRepo
         FileUtils.mkdir_p(bundler_d_path)
 
         File.write(override_path, content)
+
+        if debug
+          puts
+          puts "*" * 80
+          puts
+          puts "Contents of #{override_path}"
+          puts
+          puts File.read(override_path)
+          puts
+          puts "*" * 80
+          puts
+        end
       end
     end
 

--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -3,9 +3,9 @@ require "active_support/core_ext/object/blank"
 
 module ManageIQ::CrossRepo
   class Runner
-    attr_reader :test_repo, :core_repo, :gem_repos, :script_cmd
+    attr_reader :test_repo, :core_repo, :gem_repos, :script_cmd, :debug
 
-    def initialize(test_repo, repos, script_cmd = "")
+    def initialize(test_repo, repos, script_cmd = "", debug = false)
       @test_repo = Repository.new(test_repo || "ManageIQ/manageiq@master")
 
       core_repos, @gem_repos = Array(repos).collect { |repo| Repository.new(repo) }.partition(&:core?)
@@ -22,6 +22,7 @@ module ManageIQ::CrossRepo
       end
 
       @script_cmd = script_cmd.presence || "bundle exec rake"
+      @debug      = debug
     end
 
     def run
@@ -54,7 +55,7 @@ module ManageIQ::CrossRepo
     end
 
     def system!(*args)
-      if ENV["DEBUG"]
+      if debug
         repo = Dir.pwd.split("/").last(2).join("/")
         puts "\e[36mDEBUG: #{repo} - #{args.join(" ")}\e[0m"
       end


### PR DESCRIPTION
Was going to use this to "`--debug`" some issues wih the `ManageIQ/manageiq` Rails 6.0 effort (specifically some failing builds due in `manageiq-ui-classic`), but turns out I was able figure it out without this change.

Regardless, I could see this being useful for others, so here is a PR.


:tomato: :tomato: :tomato: