### PR TITLE
Parse .travis.yml and run before_* and after_* hooks and pass through a TEST_SUITE

### DIFF
--- a/exe/manageiq-cross_repo
+++ b/exe/manageiq-cross_repo
@@ -31,9 +31,14 @@ opts = Optimist.options do
     Can also be passed as a REPOS environment variable.
   EOS
 
-  opt :script_cmd, <<~EOS, :type => :string, :default => ENV["SCRIPT_CMD"].presence || ""
-    Optional, a command string for running the specs.  Defaults to `bundle exec rake`.
+  opt :test_suite, <<~EOS, :type => :string, :default => ENV["TEST_SUITE"].presence || ""
+    Optional, the name of a rake test suite to pass to `bundle exec rake` e.g. spec:javascript.
   EOS
+
+  opt :script_cmd, <<~EOS, :type => :string, :default => ENV["SCRIPT_CMD"].presence || ""
+    Optional, a command string for running the specs.
+  EOS
+
 
   # Manually add these so they appear in the right order in the help output
   banner ""
@@ -90,7 +95,7 @@ end
 opts[:repos] = opts[:repos].flatten.flat_map { |repo| repo.split(",").map(&:strip) }
 
 begin
-  ManageIQ::CrossRepo.run(opts[:test_repo], opts[:repos], opts[:script_cmd])
+  ManageIQ::CrossRepo.run(opts[:test_repo], opts[:repos], opts[:test_suite], opts[:script_cmd])
 rescue ArgumentError => e
   Optimist.die e
 end

--- a/exe/manageiq-cross_repo
+++ b/exe/manageiq-cross_repo
@@ -32,11 +32,14 @@ opts = Optimist.options do
   EOS
 
   opt :test_suite, <<~EOS, :type => :string, :default => ENV["TEST_SUITE"].presence || ""
-    Optional, the name of a rake test suite to pass to `bundle exec rake` e.g. spec:javascript.
+    Optional, the name of a rake test suite to pass as an environment variable to the test being run.
+    This is commonly used by the .travis.yml to conditionally perform different setup tasks
+    and also to run different test suites, e.g. spec:javascript.
   EOS
 
-  opt :script_cmd, <<~EOS, :type => :string, :default => ENV["SCRIPT_CMD"].presence || ""
+  opt :script_cmd, <<~EOS, :type => :string, :default => ENV["SCRIPT_CMD"].presence || "bundle exec rake"
     Optional, a command string for running the specs.
+    If present this will override the the script section of the test_repo's .travis.yml
   EOS
 
 

--- a/exe/manageiq-cross_repo
+++ b/exe/manageiq-cross_repo
@@ -31,13 +31,13 @@ opts = Optimist.options do
     Can also be passed as a REPOS environment variable.
   EOS
 
-  opt :test_suite, <<~EOS, :type => :string, :default => ENV["TEST_SUITE"].presence || ""
+  opt :test_suite, <<~EOS, :type => :string, :default => ENV["TEST_SUITE"].presence
     Optional, the name of a rake test suite to pass as an environment variable to the test being run.
     This is commonly used by the .travis.yml to conditionally perform different setup tasks
     and also to run different test suites, e.g. spec:javascript.
   EOS
 
-  opt :script_cmd, <<~EOS, :type => :string, :default => ENV["SCRIPT_CMD"].presence || "bundle exec rake"
+  opt :script_cmd, <<~EOS, :type => :string, :default => ENV["SCRIPT_CMD"].presence
     Optional, a command string for running the specs.
     If present this will override the the script section of the test_repo's .travis.yml
   EOS
@@ -96,9 +96,15 @@ opts = Optimist.options do
 end
 
 opts[:repos] = opts[:repos].flatten.flat_map { |repo| repo.split(",").map(&:strip) }
+test_repo, repos, test_suite, script_cmd = opts.values_at(:test_repo, :repos, :test_suite, :script_cmd)
 
 begin
-  ManageIQ::CrossRepo.run(opts[:test_repo], opts[:repos], opts[:test_suite], opts[:script_cmd])
+  ManageIQ::CrossRepo.run(
+    :test_repo  => test_repo,
+    :repos      => repos,
+    :test_suite => test_suite,
+    :script_cmd => script_cmd
+  )
 rescue ArgumentError => e
   Optimist.die e
 end

--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -5,7 +5,7 @@ module ManageIQ::CrossRepo
   class Runner
     attr_reader :test_repo, :core_repo, :gem_repos, :test_suite, :script_cmd, :install_cmd
 
-    def initialize(test_repo, repos, test_suite = "", script_cmd = "")
+    def initialize(test_repo:, repos:, test_suite: nil, script_cmd: nil)
       @test_repo = Repository.new(test_repo || "ManageIQ/manageiq@master")
 
       core_repos, @gem_repos = Array(repos).collect { |repo| Repository.new(repo) }.partition(&:core?)

--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -44,7 +44,7 @@ module ManageIQ::CrossRepo
         sections = %w[before_install install before_script script after_script]
         commands = sections.flat_map do |section|
           # Travis sections can have a single command or an array of commands
-          section_commands = Array(travis_yml[section])
+          section_commands = Array(travis_yml[section]).map { |cmd| "#{cmd} || exit $?"}
           [
             "echo 'travis_fold:start:#{section}'",
             *section_commands,
@@ -55,12 +55,10 @@ module ManageIQ::CrossRepo
         bash_script = <<~BASH_SCRIPT
           #!/bin/bash
 
-          set -e
-
           #{commands.join("\n")}
         BASH_SCRIPT
 
-        system!(env_vars, bash_script)
+        system!(env_vars, "/bin/bash -c \"#{bash_script}\"")
       end
     end
 

--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -3,7 +3,7 @@ require "active_support/core_ext/object/blank"
 
 module ManageIQ::CrossRepo
   class Runner
-    attr_reader :test_repo, :core_repo, :gem_repos, :test_suite, :script_cmd
+    attr_reader :test_repo, :core_repo, :gem_repos, :test_suite, :script_cmd, :install_cmd
 
     def initialize(test_repo, repos, test_suite = "", script_cmd = "")
       @test_repo = Repository.new(test_repo || "ManageIQ/manageiq@master")
@@ -22,6 +22,7 @@ module ManageIQ::CrossRepo
       end
 
       @script_cmd = script_cmd.presence || "bundle exec rake"
+      @install_cmd = "bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}"
       @test_suite = test_suite.presence
     end
 
@@ -41,7 +42,7 @@ module ManageIQ::CrossRepo
 
         commands =
           Array(travis_yml["before_install"]) +
-          Array(travis_yml["install"]) +
+          Array(travis_yml["install"] || install_cmd) +
           Array(travis_yml["before_script"]) +
           Array(travis_yml["script"] || script_cmd) +
           Array(travis_yml["after_script"])

--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -37,9 +37,19 @@ module ManageIQ::CrossRepo
 
     def run_tests
       with_test_env do
+        # Set missing travis sections to the proper defaults
+        travis_yml["install"] ||= install_cmd
+        travis_yml["script"] ||= script_cmd
+
         sections = %w[before_install install before_script script after_script]
         commands = sections.flat_map do |section|
-          Array(travis_yml[section])
+          # Travis sections can have a single command or an array of commands
+          section_commands = Array(travis_yml[section])
+          [
+            "echo 'travis_fold:start:#{section}'",
+            *section_commands,
+            "echo 'travis_fold:end:#{section}'"
+          ]
         end
 
         bash_script = <<~BASH_SCRIPT

--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -103,13 +103,14 @@ module ManageIQ::CrossRepo
       commands = sections.flat_map do |section|
         # Travis sections can have a single command or an array of commands
         section_commands = Array(travis_yml[section]).map { |cmd| "#{cmd} || exit $?" }
+        next if section_commands.blank?
 
         [
           "echo 'travis_fold:start:#{section}'",
           *section_commands,
           "echo 'travis_fold:end:#{section}'"
         ]
-      end
+      end.compact
 
       <<~BASH_SCRIPT
         #!/bin/bash

--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -36,9 +36,7 @@ module ManageIQ::CrossRepo
 
     def run_tests
       with_test_env do
-        load_travis_yml!
-        test_script = build_test_script
-        run_test_script(test_script)
+        run_test_script(build_test_script)
       end
     end
 
@@ -99,6 +97,8 @@ module ManageIQ::CrossRepo
     end
 
     def build_test_script
+      load_travis_yml!
+
       sections = %w[before_install install before_script script]
       commands = sections.flat_map do |section|
         # Travis sections can have a single command or an array of commands

--- a/spec/manageiq/cross_repo/runner_spec.rb
+++ b/spec/manageiq/cross_repo/runner_spec.rb
@@ -1,0 +1,35 @@
+describe ManageIQ::CrossRepo::Runner do
+  describe "#initialize" do
+    it "test_repo defaults to ManageIQ/manageiq@master" do
+      runner = described_class.new(:test_repo => nil, :repos => [])
+      expect(runner.test_repo.identifier).to eq("ManageIQ/manageiq@master")
+    end
+
+    it "core_repo defaults to ManageIQ/manageiq@master" do
+      runner = described_class.new(:test_repo => nil, :repos => [])
+      expect(runner.core_repo.identifier).to eq("ManageIQ/manageiq@master")
+    end
+
+    it "raises an exception passing different core test repo" do
+      expect {
+        described_class.new(:test_repo => "ManageIQ/manageiq@master", :repos => ["ManageIQ/manageiq@ivanchuk"])
+      }.to raise_error(ArgumentError, "You cannot pass a different core repo when running a core test")
+    end
+
+    it "raises an exception if you don't pass a repo override" do
+      expect {
+        described_class.new(:test_repo => "ManageIQ/manageiq-ui-classic", :repos => [])
+      }.to raise_error(ArgumentError, "You must pass at least one repo when running a plugin test.")
+    end
+
+    it "accepts an alternate test suite" do
+      runner = described_class.new(:test_repo => nil, :repos => [], :test_suite => "spec:javascript")
+      expect(runner.test_suite).to eq("spec:javascript")
+    end
+
+    it "accepts an alternate script command" do
+      runner = described_class.new(:test_repo => nil, :repos => [], :script_cmd => "cat db/schema.rb")
+      expect(runner.script_cmd).to eq("cat db/schema.rb")
+    end
+  end
+end

--- a/spec/manageiq/cross_repo/runner_spec.rb
+++ b/spec/manageiq/cross_repo/runner_spec.rb
@@ -32,4 +32,60 @@ describe ManageIQ::CrossRepo::Runner do
       expect(runner.script_cmd).to eq("cat db/schema.rb")
     end
   end
+
+  describe "#build_test_script (private)" do
+    let(:runner) do
+      described_class.new(:test_repo => nil, :repos => []).tap do |r|
+        require "yaml"
+        allow(r).to receive(:travis_yml).and_return(YAML.load(travis_yml))
+      end
+    end
+
+    let(:travis_yml) do
+      <<~TRAVIS_YML
+        ---
+        language: ruby
+        cache: bundler
+        script: bundle exec rake
+      TRAVIS_YML
+    end
+
+    it "builds a test script" do
+      expected_test_script = <<~SCRIPT
+        #!/bin/bash
+
+        echo 'travis_fold:start:script'
+        bundle exec rake || exit $?
+        echo 'travis_fold:end:script'
+      SCRIPT
+
+      expect(runner.send(:build_test_script)).to eq(expected_test_script)
+    end
+
+    context "with arrays of commands" do
+      let (:travis_yml) do
+        <<~TRAVIS_YML
+          ---
+          language: ruby
+          cache: bundler
+          script:
+          - bundle exec rake
+          - bundle exec rake spec:javascript
+        TRAVIS_YML
+      end
+
+      it "builds a test script with both commands" do
+        expected_test_script = <<~SCRIPT
+          #!/bin/bash
+
+          echo 'travis_fold:start:script'
+          bundle exec rake || exit $?
+          bundle exec rake spec:javascript || exit $?
+          echo 'travis_fold:end:script'
+        SCRIPT
+
+        expect(runner.send(:build_test_script)).to eq(expected_test_script)
+      end
+    end
+  end
 end

--- a/spec/manageiq/cross_repo/runner_spec.rb
+++ b/spec/manageiq/cross_repo/runner_spec.rb
@@ -46,6 +46,7 @@ describe ManageIQ::CrossRepo::Runner do
         ---
         language: ruby
         cache: bundler
+        install: bundle install
         script: bundle exec rake
       TRAVIS_YML
     end
@@ -54,6 +55,9 @@ describe ManageIQ::CrossRepo::Runner do
       expected_test_script = <<~SCRIPT
         #!/bin/bash
 
+        echo 'travis_fold:start:install'
+        bundle install || exit $?
+        echo 'travis_fold:end:install'
         echo 'travis_fold:start:script'
         bundle exec rake || exit $?
         echo 'travis_fold:end:script'
@@ -62,12 +66,38 @@ describe ManageIQ::CrossRepo::Runner do
       expect(runner.send(:build_test_script)).to eq(expected_test_script)
     end
 
+    context "with missing sections" do
+      let (:travis_yml) do
+        <<~TRAVIS_YML
+          ---
+          language: ruby
+          cache: bundler
+        TRAVIS_YML
+      end
+
+      it "uses the language defaults" do
+        expected_test_script = <<~SCRIPT
+          #!/bin/bash
+
+          echo 'travis_fold:start:install'
+          bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle} || exit $?
+          echo 'travis_fold:end:install'
+          echo 'travis_fold:start:script'
+          bundle exec rake || exit $?
+          echo 'travis_fold:end:script'
+        SCRIPT
+
+        expect(runner.send(:build_test_script)).to eq(expected_test_script)
+      end
+    end
+
     context "with arrays of commands" do
       let (:travis_yml) do
         <<~TRAVIS_YML
           ---
           language: ruby
           cache: bundler
+          install: bundle install
           script:
           - bundle exec rake
           - bundle exec rake spec:javascript
@@ -78,6 +108,9 @@ describe ManageIQ::CrossRepo::Runner do
         expected_test_script = <<~SCRIPT
           #!/bin/bash
 
+          echo 'travis_fold:start:install'
+          bundle install || exit $?
+          echo 'travis_fold:end:install'
           echo 'travis_fold:start:script'
           bundle exec rake || exit $?
           bundle exec rake spec:javascript || exit $?


### PR DESCRIPTION
Mimic travis by invoking the before_install, install, before_script, script, and after_script directives defined in the test repo's `.travis.yml`

Issues (checked off if a currently open PR fixes it):
- [x] Some repos don't call out a `:script` section but use the default for the language.  We can continue to default to `bundle exec rake` if no `:script` is defined in the `.travis.yml`
- [x] Some repos (namely core) require `TEST_SUITE` to be set, no default would work for all repos so some refactoring might be needed (e.g. have core default `rake test:setup` => `test:vmdb:setup`) - https://github.com/ManageIQ/manageiq/pull/20984 and https://github.com/ManageIQ/manageiq-ui-classic/pull/7592/files
- [x] `nvm` is a bash function and has to be loaded by sourcing `~/.nvm/nvm.sh` - https://github.com/ManageIQ/manageiq-ui-classic/pull/7592
- [x] We can't `source path/to/script` because each command is run in a different shell
- [x] For the javascript tests we have to add `chrome: beta` to cross-repo-tests' .travis.yml addons for everyone

Depends:
- [x] https://github.com/ManageIQ/manageiq-ui-classic/pull/7592
- [x] https://github.com/ManageIQ/manageiq-ui-service/pull/1696
- [x] https://github.com/ManageIQ/manageiq-v2v/pull/1153
- [x] https://github.com/ManageIQ/manageiq/pull/20984