### PR TITLE
[gemspec] Remove ActiveSupport

### DIFF
--- a/exe/manageiq-cross_repo
+++ b/exe/manageiq-cross_repo
@@ -19,25 +19,25 @@ opts = Optimist.options do
     changes you are making as a developer will affect the other test suites.
   EOS
 
-  opt :test_repo, <<~EOS, :type => :string, :default => ENV["TEST_REPO"].presence || "ManageIQ/manageiq@master"
+  opt :test_repo, <<~EOS, :type => :string, :default => ENV["TEST_REPO"] || "ManageIQ/manageiq@master"
     This is the repository which will be tested.
     Can also be passed as a TEST_REPO environment variable.
   EOS
 
-  opt :repos, <<~EOS, :type => :strings, :default => Array(ENV["REPOS"].presence)
+  opt :repos, <<~EOS, :type => :strings, :default => Array(ENV["REPOS"])
     Optional, a list of other repos and/or gems to override while running the tests.
     If any of the repositories in the list are a core repository that will
     be used as the root repository, otherwise ManageIQ/manageiq@master will be the default.
     Can also be passed as a REPOS environment variable.
   EOS
 
-  opt :test_suite, <<~EOS, :type => :string, :default => ENV["TEST_SUITE"].presence
+  opt :test_suite, <<~EOS, :type => :string, :default => ENV["TEST_SUITE"]
     Optional, the name of a rake test suite to pass as an environment variable to the test being run.
     This is commonly used by the .travis.yml to conditionally perform different setup tasks
     and also to run different test suites, e.g. spec:javascript.
   EOS
 
-  opt :script_cmd, <<~EOS, :type => :string, :default => ENV["SCRIPT_CMD"].presence
+  opt :script_cmd, <<~EOS, :type => :string, :default => ENV["SCRIPT_CMD"]
     Optional, a command string for running the specs.
     If present this will override the the script section of the test_repo's .travis.yml
   EOS

--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -1,5 +1,4 @@
 require "manageiq/cross_repo/repository"
-require "active_support/core_ext/object/blank"
 
 module ManageIQ::CrossRepo
   class Runner
@@ -12,17 +11,17 @@ module ManageIQ::CrossRepo
       @core_repo = core_repos.first
 
       if @test_repo.core?
-        raise ArgumentError, "You cannot pass a different core repo when running a core test" if @core_repo.present? && @core_repo != @test_repo
+        raise ArgumentError, "You cannot pass a different core repo when running a core test" if !@core_repo.nil? && @core_repo != @test_repo
 
         @core_repo = @test_repo
       else
-        raise ArgumentError, "You must pass at least one repo when running a plugin test." if repos.blank?
+        raise ArgumentError, "You must pass at least one repo when running a plugin test." if repos.empty?
 
         @core_repo ||= Repository.new("ManageIQ/manageiq@master")
       end
 
-      @script_cmd = script_cmd.presence
-      @test_suite = test_suite.presence
+      @script_cmd = script_cmd
+      @test_suite = test_suite
     end
 
     def run
@@ -35,7 +34,7 @@ module ManageIQ::CrossRepo
     private
 
     def bundle_path
-      app_path = Pathname.new(ENV["TRAVIS_BUILD_DIR"].presence || Pathname.pwd)
+      app_path = Pathname.new(ENV["TRAVIS_BUILD_DIR"] || Pathname.pwd)
       app_path.join("vendor", "bundle")
     end
 
@@ -110,7 +109,7 @@ module ManageIQ::CrossRepo
       commands += sections.flat_map do |section|
         # Travis sections can have a single command or an array of commands
         section_commands = Array(travis_yml[section]).map { |cmd| "#{cmd} || exit $?" }
-        next if section_commands.blank?
+        next if section_commands.empty?
 
         [
           "echo 'travis_fold:start:#{section}'",
@@ -146,7 +145,7 @@ module ManageIQ::CrossRepo
       # Set missing travis sections to the proper defaults
       travis_yml["install"] ||= travis_defaults[travis_yml["language"]]["install"]
 
-      travis_yml["script"] = script_cmd if script_cmd.present?
+      travis_yml["script"] = script_cmd unless script_cmd.nil? || script_cmd.empty?
       travis_yml["script"] ||= travis_defaults[travis_yml["language"]]["script"]
     end
 

--- a/manageiq-cross_repo.gemspec
+++ b/manageiq-cross_repo.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "simplecov"
 
-  spec.add_dependency "activesupport", "~> 6.0.3"
   spec.add_dependency "ffi-libarchive"
   spec.add_dependency "mixlib-archive"
   spec.add_dependency "optimist"


### PR DESCRIPTION
For the most part, this isn't providing much value being here, and in the places it was helping, it can be easily replaced by core Ruby methods.

Removing it avoids issues when repos like `manageiq-content` run automate code that will load in activesupport without the bundle environment to version check.  This avoids needing to keep this repo in lockstep with the rest of the `ManageIQ/*` to make sure multiple versions of `ActiveSupport` are not installed.


TODO
----

- [ ] Probably adding some more tests would not hurt, as I think some of these cases are not being properly covered.