### PR TITLE
Fix newer activesupport pulling in newer tzinfo and causing automate engine specs to fail

### DIFF
--- a/manageiq-cross_repo.gemspec
+++ b/manageiq-cross_repo.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "simplecov"
 
-  spec.add_dependency "activesupport"
+  spec.add_dependency "activesupport", "~> 6.0.3"
   spec.add_dependency "ffi-libarchive"
   spec.add_dependency "mixlib-archive"
   spec.add_dependency "optimist"


### PR DESCRIPTION
This is a workaround to prevent this specific issue, long term I'm hoping to get the manageiq bundle to not see what we install for manageiq-cross_repo

Test cross-repo test: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/369