### PR TITLE
Unpack the hash for ruby 3 support

### DIFF
--- a/lib/manageiq/cross_repo.rb
+++ b/lib/manageiq/cross_repo.rb
@@ -7,8 +7,8 @@ module ManageIQ
   module CrossRepo
     REPOS_DIR = Pathname.pwd.join("repos")
 
-    def self.run(*args)
-      Runner.new(*args).run
+    def self.run(**args)
+      Runner.new(**args).run
     end
   end
 end


### PR DESCRIPTION
In prior rubies, this hash was unpacked as the only value in an array. Ruby 3 no
longer accepts kwargs or implicit hashes as the last argument sent to a method.

Since Runner#initialize accepts only kwargs, it's far easier to just change this
to unpack the hash into kwargs using double splat.
This was tested for ruby 2.6, 2.7, and 3.0.