### PR TITLE
Announce the cross repo run information

### DIFF
--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -26,6 +26,7 @@ module ManageIQ::CrossRepo
     end
 
     def run
+      announce_run
       test_repo.ensure_clone
       core_repo.ensure_clone unless test_repo.core?
       prepare_gem_repos
@@ -33,6 +34,15 @@ module ManageIQ::CrossRepo
     end
 
     private
+
+    def announce_run
+      puts "\e[36m Starting cross repo for:\e[0m"
+      puts "  \e[36mtest repo: #{test_repo.identifier}\e[0m"
+      puts "  \e[36mcore repo: #{core_repo.identifier}\e[0m"
+      gem_repos.each do |gr|
+        puts "  \e[36mgem repo:  #{gr.identifier}\e[0m"
+      end
+    end
 
     def bundle_path
       app_path = Pathname.new(ENV["TRAVIS_BUILD_DIR"].presence || Pathname.pwd)


### PR DESCRIPTION
In the event you're running several in a batch, it's nice to report on what
we're doing and not rely on ENV variables as some could be set via command
line.

The output looks something like this:

```
 Starting cross repo for:
  test repo: ManageIQ/manageiq-providers-lenovo
  core repo: ManageIQ/manageiq#21652
  gem repo:  ManageIQ/inventory_refresh#103
Fetching https://github.com/ManageIQ/manageiq-providers-lenovo/tarball/dfeb7c99963eac29e9eb9f8f2f78ba2c9c3ee866
```

Here's the output with color.  I just picked an existing color and didn't really format it too much but thought it was helpful when running several cross repos in a batch.

![image](https://user-images.githubusercontent.com/19339/152607705-05119bfc-0566-46bc-8517-f277b0de4edf.png)
