### PR TITLE
Changes for Github Actions

### DIFF
--- a/.github/workflows/manageiq_cross_repo.yaml
+++ b/.github/workflows/manageiq_cross_repo.yaml
@@ -1,0 +1,51 @@
+name: ManageIQ Cross Repo Workflow
+
+on:
+  workflow_call:
+    inputs:
+      test-repo:
+        required: true
+        type: string
+      repos:
+        required: true
+        type: string
+      test-suite:
+        required: false
+        type: string
+
+jobs:
+  ci:
+    name: Run manageiq-cross_repo
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    services:
+      postgres:
+        image: manageiq/postgresql:10
+        env:
+          POSTGRESQL_USER: root
+          POSTGRESQL_PASSWORD: smartvm
+          POSTGRESQL_DATABASE: vmdb_test
+        options: --health-cmd pg_isready --health-interval 2s --health-timeout 5s --health-retries 5
+        ports:
+        - 5432:5432
+    env:
+      TEST_SUITE: ${{ inputs.test-suite }}
+      REPOS: ${{ inputs.repos }}
+      TEST_REPO: ${{ inputs.test-repo }}
+      PGHOST: localhost
+      PGPASSWORD: smartvm
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
+        bundler-cache: true
+    - name: Set up Node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 12
+        registry-url: https://npm.manageiq.org/
+    - name: Run tests
+      run: bundle exec manageiq-cross_repo

--- a/lib/manageiq/cross_repo/runner.rb
+++ b/lib/manageiq/cross_repo/runner.rb
@@ -57,7 +57,7 @@ module ManageIQ::CrossRepo
     end
 
     def env_vars
-      {"MANAGEIQ_REPO" => core_repo.path.to_s, "TRAVIS_BUILD_DIR" => test_repo.path.to_s, "BUNDLE_PATH" => bundle_path.to_s, "TEST_SUITE" => test_suite}
+      {"MANAGEIQ_REPO" => core_repo.path.to_s, "BUNDLE_PATH" => bundle_path.to_s, "TEST_SUITE" => test_suite}
     end
 
     def with_test_env

--- a/lib/manageiq/cross_repo/runner/base.rb
+++ b/lib/manageiq/cross_repo/runner/base.rb
@@ -4,10 +4,11 @@ require "yaml"
 module ManageIQ::CrossRepo
   class Runner
     class Base
-      attr_accessor :script_cmd
+      attr_accessor :script_cmd, :config
 
       def initialize(script_cmd = nil)
         @script_cmd = script_cmd.presence
+        @config     = load_config!
       end
 
       def build_test_script
@@ -64,11 +65,7 @@ module ManageIQ::CrossRepo
       end
 
       def load_config!
-        config
-      end
-
-      def config
-        @config ||= travis_config.tap do |config|
+        ci_config.tap do |config|
           # Set missing sections to the proper defaults
           config["install"] ||= defaults[config["language"]]["install"]
 
@@ -77,7 +74,7 @@ module ManageIQ::CrossRepo
         end
       end
 
-      def travis_config
+      def ci_config
         raise NotImplementedError, "must be implemented in a subclass"
       end
 

--- a/lib/manageiq/cross_repo/runner/base.rb
+++ b/lib/manageiq/cross_repo/runner/base.rb
@@ -50,9 +50,9 @@ module ManageIQ::CrossRepo
 
       def build_section(section, *commands)
         [
-          "echo 'travis_fold:start:#{section}'",
+          "echo '::group::#{section}'",
           *commands,
-          "echo 'travis_fold:end:#{section}'"
+          "echo '::endgroup::'"
         ]
       end
 

--- a/lib/manageiq/cross_repo/runner/github.rb
+++ b/lib/manageiq/cross_repo/runner/github.rb
@@ -12,7 +12,9 @@ module ManageIQ::CrossRepo
 
       private
 
-      def travis_config
+      def ci_config
+        github_config = YAML.load_file(CONFIG_FILE)
+
         steps = github_config["jobs"]["ci"]["steps"]
         language = steps.any? { |s| s["uses"] == "ruby/setup-ruby@v1" } ? "ruby" : "node_js"
 
@@ -20,10 +22,6 @@ module ManageIQ::CrossRepo
           script_step = steps.detect { |s| s["name"] == "Run tests" }
           config["script"] = script_step["run"] if script_step
         end
-      end
-
-      def github_config
-        YAML.load_file(CONFIG_FILE)
       end
     end
   end

--- a/lib/manageiq/cross_repo/runner/github.rb
+++ b/lib/manageiq/cross_repo/runner/github.rb
@@ -1,5 +1,6 @@
 require_relative "./base"
 require "yaml"
+require "active_support/core_ext/enumerable"
 
 module ManageIQ::CrossRepo
   class Runner
@@ -16,12 +17,17 @@ module ManageIQ::CrossRepo
         github_config = YAML.load_file(CONFIG_FILE)
 
         steps = github_config["jobs"]["ci"]["steps"]
+        steps_by_name = steps.index_by { |step| step["name"] }
+
         language = steps.any? { |s| s["uses"] == "ruby/setup-ruby@v1" } ? "ruby" : "node_js"
 
-        defaults[language].clone.tap do |config|
-          script_step = steps.detect { |s| s["name"] == "Run tests" }
-          config["script"] = script_step["run"] if script_step
-        end
+        result = {"language" => language}
+
+        result["before_install"] = steps_by_name["Set up system"]["run"] if steps_by_name["Set up system"]
+        result["before_script"]  = steps_by_name["Prepare tests"]["run"] if steps_by_name["Prepare tests"]
+        result["script"]         = steps_by_name["Run tests"]["run"]     if steps_by_name["Run tests"]
+
+        result
       end
     end
   end

--- a/lib/manageiq/cross_repo/runner/travis.rb
+++ b/lib/manageiq/cross_repo/runner/travis.rb
@@ -12,7 +12,7 @@ module ManageIQ::CrossRepo
 
       private
 
-      def travis_config
+      def ci_config
         YAML.load_file(CONFIG_FILE)
       end
     end

--- a/spec/manageiq/cross_repo/runner/github_spec.rb
+++ b/spec/manageiq/cross_repo/runner/github_spec.rb
@@ -51,18 +51,18 @@ describe ManageIQ::CrossRepo::Runner::Github do
         expected_test_script = <<~SCRIPT
           #!/bin/bash
 
-          echo 'travis_fold:start:before_install'
+          echo '::group::before_install'
           bin/before_install || exit $?
-          echo 'travis_fold:end:before_install'
-          echo 'travis_fold:start:install'
+          echo '::endgroup::'
+          echo '::group::install'
           bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle} || exit $?
-          echo 'travis_fold:end:install'
-          echo 'travis_fold:start:before_script'
+          echo '::endgroup::'
+          echo '::group::before_script'
           bin/setup || exit $?
-          echo 'travis_fold:end:before_script'
-          echo 'travis_fold:start:script'
+          echo '::endgroup::'
+          echo '::group::script'
           bundle exec rake || exit $?
-          echo 'travis_fold:end:script'
+          echo '::endgroup::'
         SCRIPT
 
         expect(runner.build_test_script).to eq(expected_test_script)
@@ -75,18 +75,18 @@ describe ManageIQ::CrossRepo::Runner::Github do
           expected_test_script = <<~SCRIPT
             #!/bin/bash
 
-            echo 'travis_fold:start:before_install'
+            echo '::group::before_install'
             bin/before_install || exit $?
-            echo 'travis_fold:end:before_install'
-            echo 'travis_fold:start:install'
+            echo '::endgroup::'
+            echo '::group::install'
             bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle} || exit $?
-            echo 'travis_fold:end:install'
-            echo 'travis_fold:start:before_script'
+            echo '::endgroup::'
+            echo '::group::before_script'
             bin/setup || exit $?
-            echo 'travis_fold:end:before_script'
-            echo 'travis_fold:start:script'
+            echo '::endgroup::'
+            echo '::group::script'
             cat db/schema.rb || exit $?
-            echo 'travis_fold:end:script'
+            echo '::endgroup::'
           SCRIPT
 
           expect(runner.build_test_script).to eq(expected_test_script)

--- a/spec/manageiq/cross_repo/runner/github_spec.rb
+++ b/spec/manageiq/cross_repo/runner/github_spec.rb
@@ -25,11 +25,15 @@ describe ManageIQ::CrossRepo::Runner::Github do
                   - '2.7'
               steps:
               - uses: actions/checkout@v2
+              - name: Set up system
+                run: bin/before_install
               - name: Set up Ruby
                 uses: ruby/setup-ruby@v1
                 with:
                   ruby-version: ${{ matrix.ruby-version }}
                   bundler-cache: true
+              - name: Prepare tests
+                run: bin/setup
               - name: Run tests
                 run: bundle exec rake
                 env:
@@ -47,9 +51,15 @@ describe ManageIQ::CrossRepo::Runner::Github do
         expected_test_script = <<~SCRIPT
           #!/bin/bash
 
+          echo 'travis_fold:start:before_install'
+          bin/before_install || exit $?
+          echo 'travis_fold:end:before_install'
           echo 'travis_fold:start:install'
           bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle} || exit $?
           echo 'travis_fold:end:install'
+          echo 'travis_fold:start:before_script'
+          bin/setup || exit $?
+          echo 'travis_fold:end:before_script'
           echo 'travis_fold:start:script'
           bundle exec rake || exit $?
           echo 'travis_fold:end:script'
@@ -65,9 +75,15 @@ describe ManageIQ::CrossRepo::Runner::Github do
           expected_test_script = <<~SCRIPT
             #!/bin/bash
 
+            echo 'travis_fold:start:before_install'
+            bin/before_install || exit $?
+            echo 'travis_fold:end:before_install'
             echo 'travis_fold:start:install'
             bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle} || exit $?
             echo 'travis_fold:end:install'
+            echo 'travis_fold:start:before_script'
+            bin/setup || exit $?
+            echo 'travis_fold:end:before_script'
             echo 'travis_fold:start:script'
             cat db/schema.rb || exit $?
             echo 'travis_fold:end:script'

--- a/spec/manageiq/cross_repo/runner/github_spec.rb
+++ b/spec/manageiq/cross_repo/runner/github_spec.rb
@@ -1,11 +1,11 @@
 describe ManageIQ::CrossRepo::Runner::Github do
   describe "#build_test_script" do
     let(:script_cmd) { nil }
-    let(:runner) do
-      described_class.new(script_cmd).tap do |r|
-        require "yaml"
-        allow(r).to receive(:github_config).and_return(YAML.load(github_yml))
-      end
+    let(:runner) { described_class.new(script_cmd) }
+
+    before do
+      require "yaml"
+      allow(YAML).to receive(:load_file).with(described_class::CONFIG_FILE).and_return(YAML.load(github_yml))
     end
 
     context "ruby" do

--- a/spec/manageiq/cross_repo/runner/travis_spec.rb
+++ b/spec/manageiq/cross_repo/runner/travis_spec.rb
@@ -1,11 +1,11 @@
 describe ManageIQ::CrossRepo::Runner::Travis do
   describe "#build_test_script" do
     let(:script_cmd) { nil }
-    let(:runner) do
-      described_class.new(script_cmd).tap do |r|
-        require "yaml"
-        allow(r).to receive(:travis_config).and_return(YAML.load(travis_yml))
-      end
+    let(:runner) { described_class.new(script_cmd) }
+
+    before do
+      require "yaml"
+      allow(YAML).to receive(:load_file).with(described_class::CONFIG_FILE).and_return(YAML.load(travis_yml))
     end
 
     context "ruby" do

--- a/spec/manageiq/cross_repo/runner/travis_spec.rb
+++ b/spec/manageiq/cross_repo/runner/travis_spec.rb
@@ -23,12 +23,12 @@ describe ManageIQ::CrossRepo::Runner::Travis do
         expected_test_script = <<~SCRIPT
           #!/bin/bash
 
-          echo 'travis_fold:start:install'
+          echo '::group::install'
           bundle install || exit $?
-          echo 'travis_fold:end:install'
-          echo 'travis_fold:start:script'
+          echo '::endgroup::'
+          echo '::group::script'
           bundle exec rake || exit $?
-          echo 'travis_fold:end:script'
+          echo '::endgroup::'
         SCRIPT
 
         expect(runner.build_test_script).to eq(expected_test_script)
@@ -41,12 +41,12 @@ describe ManageIQ::CrossRepo::Runner::Travis do
           expected_test_script = <<~SCRIPT
             #!/bin/bash
 
-            echo 'travis_fold:start:install'
+            echo '::group::install'
             bundle install || exit $?
-            echo 'travis_fold:end:install'
-            echo 'travis_fold:start:script'
+            echo '::endgroup::'
+            echo '::group::script'
             cat db/schema.rb || exit $?
-            echo 'travis_fold:end:script'
+            echo '::endgroup::'
           SCRIPT
 
           expect(runner.build_test_script).to eq(expected_test_script)
@@ -72,16 +72,16 @@ describe ManageIQ::CrossRepo::Runner::Travis do
         expected_test_script = <<~SCRIPT
           #!/bin/bash
 
-          echo 'travis_fold:start:environment'
+          echo '::group::environment'
           source ~/.nvm/nvm.sh
           nvm install 12
-          echo 'travis_fold:end:environment'
-          echo 'travis_fold:start:install'
+          echo '::endgroup::'
+          echo '::group::install'
           yarn || exit $?
-          echo 'travis_fold:end:install'
-          echo 'travis_fold:start:script'
+          echo '::endgroup::'
+          echo '::group::script'
           yarn run test || exit $?
-          echo 'travis_fold:end:script'
+          echo '::endgroup::'
         SCRIPT
 
         expect(runner.build_test_script).to eq(expected_test_script)
@@ -94,16 +94,16 @@ describe ManageIQ::CrossRepo::Runner::Travis do
           expected_test_script = <<~SCRIPT
             #!/bin/bash
 
-            echo 'travis_fold:start:environment'
+            echo '::group::environment'
             source ~/.nvm/nvm.sh
             nvm install 12
-            echo 'travis_fold:end:environment'
-            echo 'travis_fold:start:install'
+            echo '::endgroup::'
+            echo '::group::install'
             yarn || exit $?
-            echo 'travis_fold:end:install'
-            echo 'travis_fold:start:script'
+            echo '::endgroup::'
+            echo '::group::script'
             cat yarn.lock || exit $?
-            echo 'travis_fold:end:script'
+            echo '::endgroup::'
           SCRIPT
 
           expect(runner.build_test_script).to eq(expected_test_script)
@@ -124,12 +124,12 @@ describe ManageIQ::CrossRepo::Runner::Travis do
         expected_test_script = <<~SCRIPT
           #!/bin/bash
 
-          echo 'travis_fold:start:install'
+          echo '::group::install'
           bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle} || exit $?
-          echo 'travis_fold:end:install'
-          echo 'travis_fold:start:script'
+          echo '::endgroup::'
+          echo '::group::script'
           bundle exec rake || exit $?
-          echo 'travis_fold:end:script'
+          echo '::endgroup::'
         SCRIPT
 
         expect(runner.build_test_script).to eq(expected_test_script)
@@ -153,13 +153,13 @@ describe ManageIQ::CrossRepo::Runner::Travis do
         expected_test_script = <<~SCRIPT
           #!/bin/bash
 
-          echo 'travis_fold:start:install'
+          echo '::group::install'
           bundle install || exit $?
-          echo 'travis_fold:end:install'
-          echo 'travis_fold:start:script'
+          echo '::endgroup::'
+          echo '::group::script'
           bundle exec rake || exit $?
           bundle exec rake spec:javascript || exit $?
-          echo 'travis_fold:end:script'
+          echo '::endgroup::'
         SCRIPT
 
         expect(runner.build_test_script).to eq(expected_test_script)


### PR DESCRIPTION
The manageiq-cross_repo utility parses the test_repo's CI yaml file so that it can run the required setup and tests the way the repo would normally run on its own.

The support for github actions was extremely limited, essentially it did not parse the workflow yaml other than to detect if it was a ruby or a node_js type repo.  All of the actions run were simply the defaults for the language.  This does not work for more complex tests like most of the manageiq core and plugin repos.

Enhance the `ManageIQ::CrossRepo::Runner::Github` class to parse the github actions workflow file and pull out the "travis equivalent" commands for before_install, install, before_script, and script.

Follow-up:
- https://github.com/ManageIQ/miq_bot/pull/578