### PR TITLE
Add matrix to reusable workflow

### DIFF
--- a/.github/workflows/manageiq_cross_repo.yaml
+++ b/.github/workflows/manageiq_cross_repo.yaml
@@ -15,10 +15,11 @@ on:
 
 jobs:
   ci:
-    name: Run manageiq-cross_repo
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      matrix:
+        test-repo: ${{ fromJson(inputs.test-repo) }}
     services:
       postgres:
         image: manageiq/postgresql:10
@@ -32,7 +33,7 @@ jobs:
     env:
       TEST_SUITE: ${{ inputs.test-suite }}
       REPOS: ${{ inputs.repos }}
-      TEST_REPO: ${{ inputs.test-repo }}
+      TEST_REPO: ${{ matrix.test-repo }}
       PGHOST: localhost
       PGPASSWORD: smartvm
     steps:


### PR DESCRIPTION
Workaround the limit of 20 other workflows referenced in a single github workflow, https://github.community/t/too-many-workflows-are-referenced-limit-is-20/211391

Credit to https://github.community/t/reusable-workflow-with-strategy-matrix/205676/6 for the syntax of adding a matrix in to a reusable workflow