### PR TITLE
Prevent bundler v2.3.19 from being installed

### DIFF
--- a/.github/workflows/manageiq_cross_repo.yaml
+++ b/.github/workflows/manageiq_cross_repo.yaml
@@ -43,6 +43,7 @@ jobs:
       with:
         ruby-version: 2.7
         bundler-cache: true
+        bundler: 2.3.18
     - name: Set up Node
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
Bundler v2.3.19 causes problems with cross-repo with gems installed from alternate sources.