### PR TITLE
Bundler 2.3.20 resolves the issue with other sources

### DIFF
--- a/.github/workflows/manageiq_cross_repo.yaml
+++ b/.github/workflows/manageiq_cross_repo.yaml
@@ -43,7 +43,6 @@ jobs:
       with:
         ruby-version: 2.7
         bundler-cache: true
-        bundler: 2.3.18
     - name: Set up Node
       uses: actions/setup-node@v2
       with:


### PR DESCRIPTION
Follow-up to https://github.com/ManageIQ/manageiq-cross_repo/pull/91

Bundler 2.3.19 introduced a regression preventing gems from sources other than rubygems from being found during a cross-repo test run.  This PR has been reverted and released in 2.3.20