### PR TITLE
Upgrade cross repo tests to ruby 3.1

### DIFF
--- a/lib/manageiq/cross_repo/runner/base.rb
+++ b/lib/manageiq/cross_repo/runner/base.rb
@@ -88,7 +88,7 @@ module ManageIQ::CrossRepo
           },
           "ruby"    => {
             "language" => "ruby",
-            "rvm"      => ["3.0"],
+            "rvm"      => ["3.1"],
             "install"  => "bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}",
             "script"   => "bundle exec rake"
           }


### PR DESCRIPTION
cross repo tests for ui-classic are failing for me.

Locally, running ui-classic tests with ruby 3.0 are failing for me:

Before
======

```
cd manageiq-ui-classic
git checkout master
chruby 3.0
bundle exec rake

An error occurred while loading spec_helper.
Failure/Error: Vmdb::Application.initialize!

RuntimeError:
  Application has been already initialized.
# ruby/3.0.6/gems/railties-6.1.7.7/lib/rails/application.rb:390:in `initialize!'
# ruby/3.0.6/gems/railties-6.1.7.7/lib/rails/railtie.rb:207:in `public_send'
# ruby/3.0.6/gems/railties-6.1.7.7/lib/rails/railtie.rb:207:in `method_missing'
# ./spec/manageiq/config/environment.rb:5:in `<top (required)>'
# ruby/3.0.6/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
# ruby/3.0.6/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34:in `require'
# ruby/3.0.6/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
# ruby/3.0.6/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34:in `require'
```

After
=====

```
cd manageiq-ui-classic
chruby 3.1
bundle exec rake
# It works
```