### PR TITLE
Fix CHANGELOG version diff links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,11 +74,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fix an issue overriding gems whose repo name doesn't match
 
 [Unreleased]: https://github.com/ManageIQ/manageiq-cross_repo/compare/v2.3.1...HEAD
-[2.3.1]: https://github.com/ManageIQ/manageiq-cross_repo/compare/v2.3.1..v2.3.0
-[2.3.0]: https://github.com/ManageIQ/manageiq-cross_repo/compare/v2.3.0..v2.2.0
-[2.2.0]: https://github.com/ManageIQ/manageiq-cross_repo/compare/v2.2.0..v2.1.0
-[2.1.0]: https://github.com/ManageIQ/manageiq-cross_repo/compare/v2.1.0..v2.0.0
-[2.0.0]: https://github.com/ManageIQ/manageiq-cross_repo/compare/v2.0.0...v1.2.1
+[2.3.1]: https://github.com/ManageIQ/manageiq-cross_repo/compare/v2.3.0...v2.3.1
+[2.3.0]: https://github.com/ManageIQ/manageiq-cross_repo/compare/v2.2.0...v2.3.0
+[2.2.0]: https://github.com/ManageIQ/manageiq-cross_repo/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/ManageIQ/manageiq-cross_repo/compare/v2.0.0...v2.1.0
+[2.0.0]: https://github.com/ManageIQ/manageiq-cross_repo/compare/v1.2.1...v2.0.0
 [1.2.1]: https://github.com/ManageIQ/manageiq-cross_repo/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/ManageIQ/manageiq-cross_repo/compare/v1.1.3...v1.2.0
 [1.1.3]: https://github.com/ManageIQ/manageiq-cross_repo/compare/v1.1.2...v1.1.3


### PR DESCRIPTION
I blindly copied the previous release compare link then noticed that it was backwards :facepalm: 

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
