### PR TITLE
Bump the cross-repo-tests ruby version to 3.3

### DIFF
--- a/.github/workflows/manageiq_cross_repo.yaml
+++ b/.github/workflows/manageiq_cross_repo.yaml
@@ -15,7 +15,7 @@ on:
       ruby-version:
         required: false
         type: string
-        default: '["3.0"]'
+        default: '["3.3"]'
       node-version:
         required: false
         type: string


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq/pull/23142 made ruby 3.1.1 the minimum ruby version

Fixes:
https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/930
```
install
  Fetching gem metadata from [https://rubygems.org/.](https://rubygems.org/)
  Could not find gem 'Ruby
```
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
