### PR TITLE
Use `bundle config set path` not `bundle install --path`

### DIFF
--- a/lib/manageiq/cross_repo/runner/base.rb
+++ b/lib/manageiq/cross_repo/runner/base.rb
@@ -89,7 +89,7 @@ module ManageIQ::CrossRepo
           "ruby"    => {
             "language" => "ruby",
             "rvm"      => ["3.1"],
-            "install"  => "bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}",
+            "install"  => ["bundle config set path ${BUNDLE_PATH:-vendor/bundle}", "bundle install --jobs=3 --retry=3"],
             "script"   => "bundle exec rake"
           }
         }.freeze

--- a/spec/manageiq/cross_repo/runner/github_spec.rb
+++ b/spec/manageiq/cross_repo/runner/github_spec.rb
@@ -55,7 +55,8 @@ describe ManageIQ::CrossRepo::Runner::Github do
           bin/before_install || exit $?
           echo '::endgroup::'
           echo '::group::install'
-          bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle} || exit $?
+          bundle config set path ${BUNDLE_PATH:-vendor/bundle} || exit $?
+          bundle install --jobs=3 --retry=3 || exit $?
           echo '::endgroup::'
           echo '::group::before_script'
           bin/setup || exit $?
@@ -79,7 +80,8 @@ describe ManageIQ::CrossRepo::Runner::Github do
             bin/before_install || exit $?
             echo '::endgroup::'
             echo '::group::install'
-            bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle} || exit $?
+            bundle config set path ${BUNDLE_PATH:-vendor/bundle} || exit $?
+            bundle install --jobs=3 --retry=3 || exit $?
             echo '::endgroup::'
             echo '::group::before_script'
             bin/setup || exit $?

--- a/spec/manageiq/cross_repo/runner/travis_spec.rb
+++ b/spec/manageiq/cross_repo/runner/travis_spec.rb
@@ -125,7 +125,8 @@ describe ManageIQ::CrossRepo::Runner::Travis do
           #!/bin/bash
 
           echo '::group::install'
-          bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle} || exit $?
+          bundle config set path ${BUNDLE_PATH:-vendor/bundle} || exit $?
+          bundle install --jobs=3 --retry=3 || exit $?
           echo '::endgroup::'
           echo '::group::script'
           bundle exec rake || exit $?


### PR DESCRIPTION
Passing `--path` to `bundle install` is deprecated, replace with `bundle config`

```
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set path`, and stop using this flag
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
