### PR TITLE
Add test-suite to concurrency group

### DIFF
--- a/.github/workflows/manageiq_cross_repo.yaml
+++ b/.github/workflows/manageiq_cross_repo.yaml
@@ -20,7 +20,7 @@ on:
         type: string
         default: '["20"]'
 concurrency:
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: "${{ github.workflow }}-${{ github.ref }}-${{ inputs.test-suite }}"
   cancel-in-progress: true
 permissions:
   contents: read


### PR DESCRIPTION
We ran into issues testing multiple test-suites in the same run, it would cancel all but one of them due to the concurrency group matching both runs.

This adds test-suite to the concurrency group
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
